### PR TITLE
Quiet test + default=latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ on:
           description: 'Matrix OSes'
           required: true
           default: '[ "ubuntu-latest", "windows-latest", "macos-latest" ]'
+        quiet:
+          description: 'silence annotation'
+          required: false
+          default: false
 jobs:
   setup-all-matrix:
     if: ${{ github.event.inputs.extra_tests == 'true' || github.event.inputs.extra_tests == 'matrix' }}
@@ -29,6 +33,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           cache: true
+          quiet: ${{ github.event.inputs.quiet }}
       - name: Test Vulkan SDK Install
         shell: bash
         run: |

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This action automatically downloads and installs the Vulkan SDK development envi
 ```
 
 Parameters:
-- *version* (required): `N.N.N.N` style Vulkan SDK release number (or `latest` to use most recent official release).
+- *version* (optional; default=latest): `N.N.N.N` style Vulkan SDK release number (or `latest` to use most recent official release).
 - *cache* (optional; default=false): boolean indicating whether to cache the downloaded installer file between builds.
 - *quiet* (optional; default=false): when using `latest` an Annotation is added to builds with actual SDK number; set `quiet: true` to silence.
 

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ branding:
 inputs:
   version:
     description: 'official Vulkan SDK release version to use'
-    default: ''
+    default: 'latest'
     required: true
   cache:
     description: 'whether to cache the downloaded vulkan_sdk.* installer file (using github actions/cache)'


### PR DESCRIPTION
- added option for testing quiet: true via workflow dispatch
- formally make version default to latest (given that marketplace "Use" button was omitting version: completely which could lead to confusion)
