### PR TITLE
Fix macOS install with recent SDKs

### DIFF
--- a/vulkan_prebuilt_helpers.sh
+++ b/vulkan_prebuilt_helpers.sh
@@ -51,7 +51,7 @@ function install_windows() {
 
 function install_mac() {
   test -d $VULKAN_SDK && test -f vulkan_sdk.dmg
-  local mountpoint=$(hdiutil attach vulkan_sdk.dmg | grep vulkansdk | awk 'END {print $NF}')
+  local mountpoint=$(hdiutil attach vulkan_sdk.dmg | grep -i vulkansdk | awk 'END {print $NF}')
   if [[ -d $mountpoint ]] ; then
     echo "mounted dmg image: 'vulkan_sdk.dmg' (mountpoint=$mountpoint)" >&2
   else


### PR DESCRIPTION
The volume is now named "VulkanSDK". Use a case insensitive grep to support both old and new names.