### PR TITLE
Correct install error message for mac

### DIFF
--- a/vulkan_prebuilt_helpers.sh
+++ b/vulkan_prebuilt_helpers.sh
@@ -55,7 +55,7 @@ function install_mac() {
   if [[ -d $mountpoint ]] ; then
     echo "mounted dmg image: 'vulkan_sdk.dmg' (mountpoint=$mountpoint)" >&2
   else
-    echo "could not mount dmg image: vulkan_sdk.exe (mountpoint=$mountpoint)" >&2
+    echo "could not mount dmg image: vulkan_sdk.dmg (mountpoint=$mountpoint)" >&2
     exit 7
   fi
   local sdk_temp=$mountpoint


### PR DESCRIPTION
Hi!
This change corrects the error message shown when failing to mount the dmg file on macOS 🙂 