### PR TITLE
[wip] v1.1.2 staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# install-vulkan-sdk v1.1.1
+# install-vulkan-sdk v1.1.2
 
 [![test install-vulkan-sdk](https://github.com/humbletim/install-vulkan-sdk/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/humbletim/install-vulkan-sdk/actions/workflows/ci.yml)
 


### PR DESCRIPTION
prior to cutting next release want to re-run an SDK version checking script that helps produce the readme's reference point of known-working SDK version numbers. but otherwise v1.1.2 will just be bumping `action/cache@v3` => `action/cache@v4`

Note: that latest round of *node.js deprecation warnings* have been merged into `main`. 

<details><summary>For those in a hurry it is possible to adopt those changes using a commit point instead of version.</summary>

`main` at time of writing resolves into:
- humbletim/install-vulkan-sdk@c2aa128094d42ba02959a660f03e0a4e012192f9

```yaml
  uses: humbletim/install-vulkan-sdk@c2aa128094d42ba02959a660f03e0a4e012192f9
```

</details>

cc:
- #7
- #6 

