### PR TITLE
Install volk on MacOS

### DIFF
--- a/vulkan_prebuilt_helpers.sh
+++ b/vulkan_prebuilt_helpers.sh
@@ -66,7 +66,7 @@ function install_mac() {
   fi
   echo "recognized zip layout 'vulkan_sdk.zip' ${InstallVulkan}.app/Contents" >&2
   local sdk_temp=${VULKAN_SDK}.tmp
-  sudo ${InstallVulkan}.app/Contents/MacOS/${InstallVulkan} --root "$sdk_temp" --accept-licenses --default-answer --confirm-command install
+  sudo ${InstallVulkan}.app/Contents/MacOS/${InstallVulkan} --root "$sdk_temp" --accept-licenses --default-answer --confirm-command install com.lunarg.vulkan.volk
   du -hs $sdk_temp
   test -d $sdk_temp/macOS || { echo "unrecognized dmg folder layout: $sdk_temp" ; ls -l $sdk_temp ; exit 10 ; }
   cp -r $sdk_temp/macOS/* $VULKAN_SDK/


### PR DESCRIPTION
Volk is an optional component on macOS, whereas on Windows and Linux it's installed by default.
Since it's tiny, I'd just install it by default for parity between OS.