### PR TITLE
Fix macos archive templates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,11 +119,12 @@ jobs:
         with:
           limit-access-to-actor: true
       - uses: ./
+        id: composit      
         with:
           version: ${{ fromJSON(github.event.inputs.versions)[0] }}
           cache: false
       - name: Setup tmate session
-        if: failure() || ${{ contains(github.event.inputs.extra_tests, 'tmate-after') }}
+        if: steps.composite.outcome != 'success' || failure() || ${{ contains(github.event.inputs.extra_tests, 'tmate-after') }}
         uses: mxschmitt/action-tmate@v3.9
         with:
           limit-access-to-actor: true
@@ -147,3 +148,8 @@ jobs:
           cmake -B tests/build -S tests -DCMAKE_BUILD_TYPE=Release -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=.
           cmake --build tests/build --config release
           ./tests/build/test_vulkan
+      - name: Setup tmate session on failure
+        if: failure()
+        uses: mxschmitt/action-tmate@v3.9
+        with:
+          limit-access-to-actor: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
           version: ${{ fromJSON(github.event.inputs.versions)[0] }}
           cache: false
       - name: Setup tmate session
-        if: ${{ contains(github.event.inputs.extra_tests, 'tmate-after') }}
+        if: failure() || ${{ contains(github.event.inputs.extra_tests, 'tmate-after') }}
         uses: mxschmitt/action-tmate@v3.9
         with:
           limit-access-to-actor: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
         versions:
           description: 'Vulkan SDK Versions'
           required: true
-          default: '[ "1.4.309.0" ]'
+          default: '[ "1.4.321.0" ]'
         oses:
           description: 'Matrix OSes'
           required: true
@@ -119,12 +119,12 @@ jobs:
         with:
           limit-access-to-actor: true
       - uses: ./
-        id: composit      
+        id: composite
         with:
           version: ${{ fromJSON(github.event.inputs.versions)[0] }}
           cache: false
       - name: Setup tmate session
-        if: steps.composite.outcome != 'success' || failure() || ${{ contains(github.event.inputs.extra_tests, 'tmate-after') }}
+        if: steps.composite.outcome != 'success' || ${{ contains(github.event.inputs.extra_tests, 'tmate-after') }}
         uses: mxschmitt/action-tmate@v3.9
         with:
           limit-access-to-actor: true

--- a/vulkan_prebuilt_helpers.sh
+++ b/vulkan_prebuilt_helpers.sh
@@ -56,11 +56,15 @@ function install_mac() {
   local InstallVulkan
   if [[ -d InstallVulkan-${VULKAN_SDK_VERSION}.app/Contents ]] ; then
     InstallVulkan=InstallVulkan-${VULKAN_SDK_VERSION}
+  elif [[ -d vulkansdk-macOS-${VULKAN_SDK_VERSION}.app/Contents ]] ; then
+    InstallVulkan=vulkansdk-macOS-${VULKAN_SDK_VERSION}
   elif [[ -d InstallVulkan.app/Contents ]] ; then
     InstallVulkan=InstallVulkan
   else
-    echo "unrecognized zip/layout: vulkan_sdk.zip" >&2
+    echo "expecting ..vulkan.app/Contents folder (perhaps lunarg changed the archive layout again?): vulkan_sdk.zip" >&2
+    echo "file vulkan_sdk.zip" >&2
     file vulkan_sdk.zip
+    echo "unzip -t vulkan_sdk.zip" >&2
     unzip -t vulkan_sdk.zip
     exit 7
   fi


### PR DESCRIPTION
- Fixes #18

turns out that the issue wasn't zip64 support simply that lunarg decided to rework their macos archive folder names again...

recognized patterns updated to now include:
- `InstallVulkan.app/Contents`
- `InstallVulkan-${VULKAN_SDK_VERSION}.app/Contents`
- `vulkansdk-macOS-${VULKAN_SDK_VERSION}/Contents` *(<-- this is the new pattern observed with SDK 1.4.321.0)*

