### PR TITLE
Accommodate upstream Windows vulkan_sdk.exe structure changes 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./
+        id: composite
         with:
           version: ${{ fromJSON(github.event.inputs.versions)[0] }}
           cache: false
@@ -75,7 +76,13 @@ jobs:
           dir .\tests\build\test_vulkan.exe
           echo testing...
           set PATH=%PATH%;%VULKAN_SDK%/Bin
-          .\tests\build\test_vulkan || echo COMPILE TEST ONLY COULD NOT RUN || exit /b 4           
+          .\tests\build\test_vulkan || echo COMPILE TEST ONLY COULD NOT RUN || exit /b 4
+      - name: Setup tmate session on failure
+        if: failure()
+        uses: mxschmitt/action-tmate@v3.9
+        with:
+          limit-access-to-actor: true
+
 
   test-prebuilt-linux:
     if: ${{ contains(github.event.inputs.extra_tests, 'prebuilt-linux') }}

--- a/vulkan_prebuilt_helpers.sh
+++ b/vulkan_prebuilt_helpers.sh
@@ -61,7 +61,7 @@ function _install_windows_7z() {
 #   and delegates accordingly
 function install_windows() {
   test -d $VULKAN_SDK && test -f vulkan_sdk.exe
-  if [[ 7z l vulkan_sdk.exe | grep Include/ >/dev/null ]] ; then
+  if 7z l vulkan_sdk.exe | grep Include/ >/dev/null ; then
     _install_windows_7z
   else
     _install_windows_qt

--- a/vulkan_prebuilt_helpers.sh
+++ b/vulkan_prebuilt_helpers.sh
@@ -45,9 +45,34 @@ function install_linux() {
   tar -C "$VULKAN_SDK" --strip-components 2 -xf vulkan_sdk.tar.gz $VULKAN_SDK_VERSION/x86_64
 }
 
+# newer SDK installers apparently need to be executed (7z only sees Bin/)
+function _install_windows_qt() {
+  test -d $VULKAN_SDK && test -f vulkan_sdk.exe
+  echo "Executing Vulkan SDK installer headlessly to $VULKAN_SDK..." >&2
+  ./vulkan_sdk.exe --root "$VULKAN_SDK" --accept-licenses --default-answer --confirm-command install
+}
+# older SDK installers could be reliably extracteed via 7z.exe
+function _install_windows_7z() {
+  test -d $VULKAN_SDK && test -f vulkan_sdk.exe
+  echo "Using 7z to unpack Vulkan SDK installer headlessly to $VULKAN_SDK..." >&2
+  7z x vulkan_sdk.exe -aoa -o$VULKAN_SDK
+}
+# FIXME: to avoid breaking those using "older" SDKs this checks 7z viability
+#   and delegates accordingly
 function install_windows() {
   test -d $VULKAN_SDK && test -f vulkan_sdk.exe
-  7z x vulkan_sdk.exe -aoa -o$VULKAN_SDK
+  if [[ 7z l vulkan_sdk.exe | grep Include/ >/dev/null ]] ; then
+    _install_windows_7z
+  else
+    _install_windows_qt
+  fi
+  # Verify that the installation was successful by checking for a key directory
+  if [ ! -d "$VULKAN_SDK/Include" ]; then
+    echo "Installer did not create the expected Include directory." >&2
+    # You can add more detailed logging here, like listing the contents of VULKAN_SDK
+    ls -l "$VULKAN_SDK" >&2
+    exit 1
+  fi
 }
 
 function install_mac() {


### PR DESCRIPTION
This PR addresses an issue with the Vulkan SDK installation on Windows, where recent changes to the installer's structure broke the existing `7z` extraction method and caused `FindVulkan` to fail in CMake.

#### Problem
Sometime in the recent past the internal layout of the official Vulkan SDK installers for Windows was modified. As a result, simply extracting the archive with `7z` no longer provides the necessary SDK headers (`Include/` directory), making the SDK unusable for compilation.

#### Solution
This PR implements a more robust, "fall-forward" installation strategy for Windows:
1.  It first inspects the `vulkan_sdk.exe` archive to see if the `Include/` directory is present at the top level.
2.  If it is (indicating an older layout), it uses the original, safer `7z` extraction method.
3.  If not, it falls forward to invoking the installer in a headless, unattended mode, similar to the method already used for macOS.

The command used for the new unattended installation is:
`./vulkan_sdk.exe --root "$VULKAN_SDK" --accept-licenses --default-answer --confirm-command install`

#### Commentary
While invoking the installer directly is a pragmatic solution, the original preference for `7z` was intentional. Surgically extracting contents is a security-conscious approach that minimizes the potential for side-effects (e.g., avoids creating system menu shortcuts, modifying the registry, or attempting to install other dependencies). It also aligns with the core principle of this action: providing a self-contained SDK environment without system-wide modifications.

The need for this change highlights a recurring challenge for open-source maintainers who depend on pre-built artifacts. Seemingly arbitrary changes to tooling and packaging can have a cascading effect, creating downstream work for the volunteer community. A more stable and predictable release process from SDK providers would be beneficial for the entire ecosystem..

See also:
- #19
CC:
- #17

