### PR TITLE
Add support for Windows ARM64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
         oses:
           description: 'Matrix OSes'
           required: true
-          default: '[ "ubuntu-latest", "windows-latest", "macos-latest" ]'
+          default: '[ "ubuntu-latest", "windows-latest", "macos-latest", "windows-11-arm" ]'
         quiet:
           description: 'silence annotation'
           required: false
@@ -46,7 +46,10 @@ jobs:
 
   test-prebuilt-windows:
     if: ${{ contains(github.event.inputs.extra_tests, 'prebuilt-windows') }}
-    runs-on: windows-latest
+    strategy:
+      matrix:
+        os: [windows-latest, windows-11-arm]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Know working SDK version for windows/mac/linux:
 - 1.4.309.0
 
 ##### Available SDK versions:
-  - [windows.json](https://vulkan.lunarg.com/sdk/versions/windows.json)
+  - [windows.json](https://vulkan.lunarg.com/sdk/versions/windows.json) / [warm.json](https://vulkan.lunarg.com/sdk/versions/warm.json)
   - [linux.json](https://vulkan.lunarg.com/sdk/versions/linux.json)
   - [mac.json](https://vulkan.lunarg.com/sdk/versions/mac.json) (version >= 1.3.296.0)
   - see also https://vulkan.lunarg.com/sdk/home

--- a/action.yml
+++ b/action.yml
@@ -25,10 +25,16 @@ runs:
         # preset env
         basedir=$PWD
         runner_os=${RUNNER_OS:-`uname -s`}
+        runner_arch=${RUNNER_ARCH:-`uname -m`}
         case $runner_os in
           macOS|Darwin) os=mac ;;
           Linux) os=linux ;;
-          Windows|MINGW*) os=windows ; basedir=$(pwd -W) ;;
+          Windows|MINGW*)
+            case $runner_arch in
+              X64|x86_64) os=windows ;;
+              ARM64|aarch64) os=warm ;;
+              *) echo "unknown runner_arch: $runner_arch" ; exit 7 ; ;;
+            esac ; basedir=$(pwd -W) ;;
           *) echo "unknown runner_os: $runner_os" ; exit 7 ; ;;
         esac
         version=${VULKAN_SDK_VERSION:-${{ inputs.version }}}

--- a/action.yml
+++ b/action.yml
@@ -25,10 +25,16 @@ runs:
         # preset env
         basedir=$PWD
         runner_os=${RUNNER_OS:-`uname -s`}
+        runner_arch=${RUNNER_ARCH:-`uname -m`}
         case $runner_os in
           macOS|Darwin) os=mac ;;
           Linux) os=linux ;;
-          Windows|MINGW*) os=windows ; basedir=$(pwd -W) ;;
+          Windows|MINGW*)
+            case $runner_arch in
+              X64|x86_64) os=windows ;;
+              ARM64|aarch64) os=warm ;;
+              *) echo "unknown runner_arch: $runner_arch" ; exit 7 ; ;;
+            esac ; basedir=$(pwd -W) ;;
           *) echo "unknown runner_os: $runner_os" ; exit 7 ; ;;
         esac
         version=${VULKAN_SDK_VERSION:-${{ inputs.version }}}
@@ -53,7 +59,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: vulkan_sdk.*
-        key: ${{ runner.os }}-vulkan-prebuilt-sdk-${{ inputs.cache }}-${{ env.VULKAN_SDK_VERSION }}
+        key: ${{ env.VULKAN_SDK_PLATFORM }}-vulkan-prebuilt-sdk-${{ inputs.cache }}-${{ env.VULKAN_SDK_VERSION }}
 
     - name: Download Vulkan SDK
       shell: bash

--- a/vulkan_prebuilt_helpers.sh
+++ b/vulkan_prebuilt_helpers.sh
@@ -12,7 +12,7 @@ function _os_filename() {
   case $1 in
     mac) echo vulkan_sdk.zip ;;
     linux) echo vulkan_sdk.tar.gz ;;
-    windows) echo vulkan_sdk.exe ;;
+    windows|warm) echo vulkan_sdk.exe ;;
     *) echo "unknown $1" >&2 ; exit 9 ;;
   esac
 }
@@ -48,6 +48,11 @@ function install_linux() {
 function install_windows() {
   test -d $VULKAN_SDK && test -f vulkan_sdk.exe
   7z x vulkan_sdk.exe -aoa -o$VULKAN_SDK
+}
+
+function install_warm() {
+  # Windows ARM installs the same way as Windows
+  install_windows
 }
 
 function install_mac() {


### PR DESCRIPTION
This PR introduces support for installing the Windows ARM64 Vulkan SDK, which has been published since SDK version 1.3.290.0. LunarG publishes their Windows ARM64 binaries under the `warm` moniker (analogous to `windows` for x64 binaries).

This change depends on #21 to properly install the entire SDK, since all ARM64 SDK versions used the newer Qt installer that can't be fully extracted with 7z. I ran a test [here](https://github.com/cgutman/install-vulkan-sdk/actions/runs/17968430946/job/51105372850) with these changes rebased atop #21 and the tests all pass.