### PR TITLE
Update to `actions/cache@v5` to fix warning

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ runs:
     - name: Check Vulkan SDK installer cache
       id: vulkan-cached-sdk
       if: inputs.cache != 'false'
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: vulkan_sdk.*
         key: ${{ runner.os }}-vulkan-prebuilt-sdk-${{ inputs.cache }}-${{ env.VULKAN_SDK_VERSION }}


### PR DESCRIPTION
Runners using the install-vulkan-sdk action are currently logging the following warning:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

This is fixed by updating to `actions/cache@v5`, which uses node 24.