### PR TITLE
fix: support Vulkan SDK 1.4.313.0+ on Windows using silent installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
           version: ${{ fromJSON(github.event.inputs.versions)[0] }}
           cache: false
       - name: Setup tmate session
-        if: steps.composite.outcome != 'success' || ${{ contains(github.event.inputs.extra_tests, 'tmate-after') }}
+        if: steps.composite.outcome != 'success' || contains(github.event.inputs.extra_tests, 'tmate-after')
         uses: mxschmitt/action-tmate@v3.9
         with:
           limit-access-to-actor: true

--- a/vulkan_prebuilt_helpers.sh
+++ b/vulkan_prebuilt_helpers.sh
@@ -17,6 +17,16 @@ function _os_filename() {
   esac
 }
 
+function _version_ge() {
+  local IFS=.
+  local i v1=($1) v2=($2)
+  for ((i=0; i<${#v1[@]} || i<${#v2[@]}; i++)); do
+    if (( ${v1[i]:-0} > ${v2[i]:-0} )); then return 0; fi
+    if (( ${v1[i]:-0} < ${v2[i]:-0} )); then return 1; fi
+  done
+  return 0
+}
+
 function download_vulkan_installer() {
   local os=$1
   local filename=$(_os_filename $os)
@@ -46,8 +56,14 @@ function install_linux() {
 }
 
 function install_windows() {
-  test -d $VULKAN_SDK && test -f vulkan_sdk.exe
-  7z x vulkan_sdk.exe -aoa -o$VULKAN_SDK
+  test -d "$VULKAN_SDK" && test -f vulkan_sdk.exe
+  if _version_ge "$VULKAN_SDK_VERSION" "1.4.313.0" ; then
+    echo "installing via installer command-line (version >= 1.4.313.0)" >&2
+    ./vulkan_sdk.exe --root "$VULKAN_SDK" --accept-licenses --default-answer --confirm-command install
+  else
+    echo "installing via 7z extraction (version < 1.4.313.0)" >&2
+    7z x vulkan_sdk.exe -aoa -o"$VULKAN_SDK"
+  fi
 }
 
 function install_mac() {


### PR DESCRIPTION
### Summary

This PR fixes the Windows installation failure for Vulkan SDK versions **1.4.313.0** and later.

### The Problem

Starting from version **1.4.313.0**, LunarG changed the internal structure of the Vulkan SDK Windows installer. As a result, the previous method of simply extracting the `.exe` via `7z` no longer produces the expected directory structure (Headers, Libs, etc. are missing or misplaced).

### The Solution

I have updated the `install_windows` function to:

1. **Check the SDK version**: It uses a version comparison to determine the installation method.
2. **Use Silent Installation**: For version `1.4.313.0` and above, it executes the installer with CLI flags (`--root`, `--accept-licenses`, `--default-answer`, `--confirm-command install`) to perform a proper installation.
3. **Maintain Backward Compatibility**: Versions older than `1.4.313.0` still use the `7z` extraction method to ensure no regression.

### Verification

I have verified this fix in my own project's CI pipeline. You can see the successful installation here:
[hollykbuck/qwen3-asr.cpp/actions/runs](https://github.com/hollykbuck/qwen3-asr.cpp/actions/runs/25633628848/job/75241569134)
